### PR TITLE
Fixed DtR link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Backing Redis with a disk makes it resilient to data loss in the case of restart
 
 Use the button below to deploy a persistent Redis instance on Render.
 
-[![Deploy to Render](http://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy)
+[![Deploy to Render](http://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/render-examples/redis)
 
 ### Manual Deployment
 


### PR DESCRIPTION
The DtR pointed to the `deploy` page. It needs to be `https://render.com/deploy?repo=https://github.com/render-examples/redis`.