### PR TITLE
Set port to default port of 6379

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Use the button below to deploy a persistent Redis instance on Render.
 
 3. Add a new disk in the `Advanced` section. Give it a name and set the mount path to `/var/lib/redis`. You can also change the default size for your disk: `1 GB` should be enough for small projects.
 
-Click `Save` and you're good to go! Once deployed, your Redis instance will be available on a URL similar to `redis:10000`, and you can start using your Redis URL from other services in your Render account. Be sure to prepend `redis://` to the URL displayed in your dashboard.
+Click `Save` and you're good to go! Once deployed, your Redis instance will be available on a URL similar to `redis:6379`, and you can start using your Redis URL from other services in your Render account. Be sure to prepend `redis://` to the URL displayed in your dashboard.
 
 If you need help, you can always chat with us at https://render.com/chat.
 

--- a/redis.conf
+++ b/redis.conf
@@ -89,7 +89,7 @@
 
 # Accept connections on the specified port, default is 6379 (IANA #815344).
 # If port 0 is specified Redis will not listen on a TCP socket.
-port 10000
+port 6379
 
 # TCP listen() backlog.
 #


### PR DESCRIPTION
6379 is the default port for Redis. This is a hardcoded assumption for many codebases including zulip. 

Setting the default port for this repo to 6379 gets rid of an integration issue that users might encounter